### PR TITLE
Gaussian copula estimation fixed.

### DIFF
--- a/pycop/bivariate/gaussian.py
+++ b/pycop/bivariate/gaussian.py
@@ -1,5 +1,9 @@
+import numpy as np
 from scipy.stats import norm, multivariate_normal
+from scipy.special import erfinv
 from pycop.bivariate.copula import copula
+
+
 class gaussian(copula):
     """
     # Creates a gaussian copula object
@@ -13,9 +17,9 @@ class gaussian(copula):
 
     Methods
     -------
-    get_cdf(u, v, rho)
+    get_cdf(u, v, param)
         Computes the Cumulative Distribution Function (CDF).
-    get_pdf(u, v, rho)
+    get_pdf(u, v, param)
         Computes the Probability Density Function (PDF).
     """
 
@@ -23,8 +27,12 @@ class gaussian(copula):
         # the `gaussian` copula class inherit the `copula` class
         super().__init__()
         self.family = "gaussian"
+        
+        # My addition
+        self.bounds_param = [(-1, 1)]
+        self.parameters_start = np.array(0) 
 
-    def get_cdf(self, u, v, rho):
+    def get_cdf(self, u, v, param):
         """
         # Computes the CDF
 
@@ -32,17 +40,18 @@ class gaussian(copula):
         ----------
         u, v : float
             Values of the marginal CDFs 
-        rho : float
-            The correlation coefficient rho ∈ [-1,1].
+        param : list
+            The correlation coefficient param[0] ∈ [-1,1].
             Used to defined the correlation matrix (squared, symetric and definite positive)
         """
 
         y1 = norm.ppf(u, 0, 1)
         y2 = norm.ppf(v, 0, 1)
+        rho = param[0]
 
-        return multivariate_normal.cdf((y1,y2), mean=None, cov=[[1,rho[0]],[rho[0],1]])
+        return multivariate_normal.cdf((y1,y2), mean=None, cov=[[1,rho],[rho,1]])
 
-    def get_pdf(self, u, v, rho):
+    def get_pdf(self, u, v, param):
         """
         # Computes the PDF
 
@@ -50,14 +59,16 @@ class gaussian(copula):
         ----------
         u, v : float
             Values of the marginal CDFs 
-        rho : float
-            The correlation coefficient rho ∈ [-1,1].
+        param : list
+            The correlation coefficient param[0] ∈ [-1,1].
             Used to defined the correlation matrix (squared, symetric and definite positive)
         """
-
-        y1 = norm.ppf(u, 0, 1)
-        y2 = norm.ppf(v, 0, 1)
-
-        return multivariate_normal.pdf((y1,y2), mean=None, cov=[[1,rho[0]],[rho[0],1]])/(norm.pdf(y1)*norm.pdf(y2))
+        
+        rho = param[0]
+        a = np.sqrt(2)*erfinv(2*u-1)
+        b = np.sqrt(2)*erfinv(2*v-1)
+        
+        
+        return (1/np.sqrt(1-rho**2))*np.exp(-((a**2 + b**2)*rho**2 -2*a*b*rho)/(2*(1-rho**2)))
 
 


### PR DESCRIPTION
I found problems with the estimation of the Gaussian copula (standalone or in a mixture of copulas).
The main issue is the usage of the `scipy.stats.multivariate_normal` module in the calculation of the pdf of Gaussian copula.
As such I avoided it and calculated the Gaussian copula density explicitly. This change fixed the estimation issues.